### PR TITLE
Fixed a slight oversight with `preUpdate` signal

### DIFF
--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -775,9 +775,10 @@ class FlxGame extends Sprite
 
 		updateElapsed();
 
-		FlxG.signals.preUpdate.dispatch();
-
 		updateInput();
+
+		// This caused issues if it was before `updateInput`.. so uh yeah FINALLY I FIXED A BUG THATS BEEN IN CNE FOR LIKE YEARS :SOB: - LJ
+		FlxG.signals.preUpdate.dispatch();
 
 		#if FLX_POST_PROCESS
 		if (postProcesses[0] != null)


### PR DESCRIPTION
It would run before the `updateInput` so if you checked for inputs in `GlobalScript` in CodenameEngine, it would run a function twice with a `justPressed` input.

This should fix the issue and not cause any other issues alongside it... hopefully 😭🙏