### PR TITLE
Fixed fastSinCos

### DIFF
--- a/flixel/math/FlxMath.hx
+++ b/flixel/math/FlxMath.hx
@@ -555,15 +555,32 @@ class FlxMath
 	{
 		var n = angle * 0.3183098862;
 
-		if (n > 1.0 || n < -1.0)
+		if (n > 1)
 		{
-			n -= Math.ffloor(n * 0.5 + 0.5) * 2.0;
+			n -= (Math.ceil(n) >> 1) << 1;
+		}
+		else if (n < -1)
+		{
+			n += (Math.ceil(-n) >> 1) << 1;
 		}
 
-		final n2 = n * n;
+		var sin:Float;
+		if (n > 0)
+		{
+			sin = n * (3.1 + n * (0.5 + n * (-7.2 + n * 3.6)));
+		}
+		else
+		{
+			sin = n * (3.1 - n * (0.5 + n * (7.2 + n * 3.6)));
+		}
 
-		final sin = n * (3.1 + n2 * (0.5 + n2 * (-7.2 + n2 * 3.6)));
-		final cos = 1.0 - 0.5 * n2 + 0.0417 * n2 * n2 - 0.00139 * n2 * n2 * n2;
+		var cos = Math.sqrt(1 - sin * sin);
+
+		var originalN = n * Math.PI;
+		if (originalN < -Math.PI * 0.5 || originalN > Math.PI * 0.5)
+		{
+			cos = -cos;
+		}
 
 		return {sin: sin, cos: cos};
 	}


### PR DESCRIPTION
**Red: `FlxMath.fastSinCos`**
**Green: `FlxMath.fastSin` & `FlxMath.fastCos`**
**Blue: `Math.sin` & `Math.cos`**

**For `FlxMath.fastSinCos`, the top graph shows before the fix, and the bottom graph shows after.**
![5c23ca83f2ba094ecca866df38a291de](https://github.com/user-attachments/assets/4a9a3953-43fc-47b0-bec2-fe9bbb214448)
![49b4d6bdb082d709efdfd84445d425ea](https://github.com/user-attachments/assets/3d18cf92-e23f-4704-bcce-945162a4bbfc)


Since I only tested performance before and forgot to test precision, I have now corrected it.

**Test results (100 million iterations):**
*   Native `Math.sin` + `cos`: **2.419 seconds**
*   `FlxMath.fastSin` + `fastCos`: **0.915000000000001 seconds**
*   `FlxMath.fastSinCos`: **0.644 seconds**