### PR TITLE
Animation Playback Adjustment

### DIFF
--- a/flixel/animation/FlxAnimation.hx
+++ b/flixel/animation/FlxAnimation.hx
@@ -177,7 +177,7 @@ class FlxAnimation extends FlxBaseAnimation
 
 		reversed = Reversed;
 		paused = false;
-		_frameTimer = 0;
+		_frameTimer = -FlxG.elapsed / 2;
 		finished = frameDuration == 0;
 
 		var maxFrameIndex:Int = numFrames - 1;

--- a/flixel/math/FlxMath.hx
+++ b/flixel/math/FlxMath.hx
@@ -555,15 +555,32 @@ class FlxMath
 	{
 		var n = angle * 0.3183098862;
 
-		if (n > 1.0 || n < -1.0)
+		if (n > 1)
 		{
-			n -= Math.ffloor(n * 0.5 + 0.5) * 2.0;
+			n -= (Math.ceil(n) >> 1) << 1;
+		}
+		else if (n < -1)
+		{
+			n += (Math.ceil(-n) >> 1) << 1;
 		}
 
-		final n2 = n * n;
+		var sin:Float;
+		if (n > 0)
+		{
+			sin = n * (3.1 + n * (0.5 + n * (-7.2 + n * 3.6)));
+		}
+		else
+		{
+			sin = n * (3.1 - n * (0.5 + n * (7.2 + n * 3.6)));
+		}
 
-		final sin = n * (3.1 + n2 * (0.5 + n2 * (-7.2 + n2 * 3.6)));
-		final cos = 1.0 - 0.5 * n2 + 0.0417 * n2 * n2 - 0.00139 * n2 * n2 * n2;
+		var cos = Math.sqrt(1 - sin * sin);
+
+		var originalN = n * Math.PI;
+		if (originalN < -Math.PI * 0.5 || originalN > Math.PI * 0.5)
+		{
+			cos = -cos;
+		}
 
 		return {sin: sin, cos: cos};
 	}

--- a/flixel/math/FlxMath.hx
+++ b/flixel/math/FlxMath.hx
@@ -549,6 +549,26 @@ class FlxMath
 	}
 
 	/**
+	 * ~1.3x faster than calling fastSin() + fastCos() separately.
+	 */
+	public static inline function fastSinCos(angle:Float):{sin:Float, cos:Float}
+	{
+		var n = angle * 0.3183098862;
+
+		if (n > 1.0 || n < -1.0)
+		{
+			n -= Math.ffloor(n * 0.5 + 0.5) * 2.0;
+		}
+
+		final n2 = n * n;
+
+		final sin = n * (3.1 + n2 * (0.5 + n2 * (-7.2 + n2 * 3.6)));
+		final cos = 1.0 - 0.5 * n2 + 0.0417 * n2 * n2 - 0.00139 * n2 * n2 * n2;
+
+		return {sin: sin, cos: cos};
+	}
+
+	/**
 	 * Hyperbolic sine.
 	 */
 	public static inline function sinh(n:Float):Float


### PR DESCRIPTION
**Previously, if an animation was played while the game was running at a low frame rate, it was very noticeable that the first frame played inexplicably fast.**

**The reason was that after `play()` was called, `_frameTimer` was set to 0. Then, in the subsequent `update`, it would immediately update with `_frameTimer += elapsed * timeScale;`.**

**I could have simply moved `_frameTimer += elapsed * timeScale;` below the `if` check, but doing so would cause noticeable delays in animation playback at low frame rates, and even result in stiffness when `play()` was called frequently. Therefore, I implemented this compromise solution.**